### PR TITLE
Rename offset class to date

### DIFF
--- a/coverage/.last_run.json
+++ b/coverage/.last_run.json
@@ -1,5 +1,5 @@
 {
   "result": {
-    "covered_percent": 91.67
+    "covered_percent": 100.0
   }
 }

--- a/coverage/.resultset.json
+++ b/coverage/.resultset.json
@@ -22,17 +22,8 @@
         null,
         null,
         null
-      ],
-      "/Users/williammeighan/turing/1module/projects/enigma/lib/offset.rb": [
-        1,
-        null,
-        1,
-        0,
-        null,
-        null,
-        null
       ]
     },
-    "timestamp": 1578705788
+    "timestamp": 1578769624
   }
 }

--- a/coverage/index.html
+++ b/coverage/index.html
@@ -14,27 +14,27 @@
       <img src="./assets/0.10.2/loading.gif" alt="loading"/>
     </div>
     <div id="wrapper" style="display:none;">
-      <div class="timestamp">Generated <abbr class="timeago" title="2020-01-10T18:23:08-07:00">2020-01-10T18:23:08-07:00</abbr></div>
+      <div class="timestamp">Generated <abbr class="timeago" title="2020-01-11T12:07:04-07:00">2020-01-11T12:07:04-07:00</abbr></div>
       <ul class="group_tabs"></ul>
 
       <div id="content">
         <div class="file_list_container" id="AllFiles">
   <h2>
     <span class="group_name">All Files</span>
-    (<span class="covered_percent"><span class="green">91.67%</span></span>
+    (<span class="covered_percent"><span class="green">100.0%</span></span>
      covered at
      <span class="covered_strength">
-       <span class="yellow">
-         1.0
+       <span class="green">
+         1.1
        </span>
     </span> hits/line)
   </h2>
   <a name="AllFiles"></a>
   <div>
-    <b>3</b> files in total.
-    <b>12</b> relevant lines. 
-    <span class="green"><b>11</b> lines covered</span> and
-    <span class="red"><b>1</b> lines missed </span>
+    <b>2</b> files in total.
+    <b>9</b> relevant lines. 
+    <span class="green"><b>9</b> lines covered</span> and
+    <span class="red"><b>0</b> lines missed </span>
   </div>
   <table class="file_list">
     <thead>
@@ -58,16 +58,6 @@
         <td>3</td>
         <td>0</td>
         <td>1.3</td>
-      </tr>
-      
-      <tr>
-        <td class="strong"><a href="#bddbfcb1e5ed787d98aedf586c278b7b95afc139" class="src_link" title="lib/offset.rb">lib/offset.rb</a></td>
-        <td class="red strong">66.67 %</td>
-        <td>7</td>
-        <td>3</td>
-        <td>2</td>
-        <td>1</td>
-        <td>0.7</td>
       </tr>
       
       <tr>
@@ -157,67 +147,6 @@
 </div>
 
       
-        <div class="source_table" id="bddbfcb1e5ed787d98aedf586c278b7b95afc139">
-  <div class="header">
-    <h3>lib/offset.rb</h3>
-    <h4><span class="red">66.67 %</span> covered</h4>
-    <div>
-      <b>3</b> relevant lines. 
-      <span class="green"><b>2</b> lines covered</span> and
-      <span class="red"><b>1</b> lines missed.</span>
-    </div>
-  </div>
-  
-  <pre>
-    <ol>
-      
-        <li class="covered" data-hits="1" data-linenumber="1">
-          <span class="hits">1</span>
-          
-          <code class="ruby">class Offset</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="2">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="covered" data-hits="1" data-linenumber="3">
-          <span class="hits">1</span>
-          
-          <code class="ruby">  def self.current_date</code>
-        </li>
-      
-        <li class="missed" data-hits="0" data-linenumber="4">
-          
-          
-          <code class="ruby">    Time.now.strftime(&quot;%d%m%y&quot;)</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="5">
-          
-          
-          <code class="ruby">  end</code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="6">
-          
-          
-          <code class="ruby"></code>
-        </li>
-      
-        <li class="never" data-hits="" data-linenumber="7">
-          
-          
-          <code class="ruby">end</code>
-        </li>
-      
-    </ol>
-  </pre>
-</div>
-
-      
         <div class="source_table" id="ce9f94e3564cc10b0f387df335c19bcba20463c3">
   <div class="header">
     <h3>test/offset_test.rb</h3>
@@ -241,7 +170,7 @@
         <li class="covered" data-hits="1" data-linenumber="2">
           <span class="hits">1</span>
           
-          <code class="ruby">require_relative &#39;../lib/offset&#39;</code>
+          <code class="ruby">require_relative &#39;../lib/date&#39;</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="3">
@@ -253,7 +182,7 @@
         <li class="covered" data-hits="1" data-linenumber="4">
           <span class="hits">1</span>
           
-          <code class="ruby">class OffsetTest &lt; Minitest::Test</code>
+          <code class="ruby">class DateTest &lt; Minitest::Test</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="5">
@@ -271,13 +200,13 @@
         <li class="covered" data-hits="1" data-linenumber="7">
           <span class="hits">1</span>
           
-          <code class="ruby">    Offset.stubs(:current_date).returns(&quot;100120&quot;)</code>
+          <code class="ruby">    Date.stubs(:current_date).returns(&quot;100120&quot;)</code>
         </li>
       
         <li class="covered" data-hits="1" data-linenumber="8">
           <span class="hits">1</span>
           
-          <code class="ruby">    assert_equal &quot;100120&quot;, Offset.current_date</code>
+          <code class="ruby">    assert_equal &quot;100120&quot;, Date.current_date</code>
         </li>
       
         <li class="never" data-hits="" data-linenumber="9">

--- a/lib/date.rb
+++ b/lib/date.rb
@@ -1,4 +1,4 @@
-class Offset
+class Date
 
   def self.current_date
     Time.now.strftime("%d%m%y")

--- a/test/offset_test.rb
+++ b/test/offset_test.rb
@@ -1,11 +1,11 @@
 require_relative 'test_helper'
-require_relative '../lib/offset'
+require_relative '../lib/date'
 
-class OffsetTest < Minitest::Test
+class DateTest < Minitest::Test
 
   def test_it_can_generate_current_date
-    Offset.stubs(:current_date).returns("100120")
-    assert_equal "100120", Offset.current_date
+    Date.stubs(:current_date).returns("100120")
+    assert_equal "100120", Date.current_date
   end
 
 end


### PR DESCRIPTION
I originally was considering doing the entire offset calculations within the same class (getting the last four digits of the sqaured date), but since the encrypt and decrypt methods will require an argument of the date only, I think I am going to leave it as is and pass in a Date object as the argument. Will use the shift class to do the remaining calculations. 